### PR TITLE
Add column count display for cleaned CSV files

### DIFF
--- a/app/blueprints/file_manager/routes.py
+++ b/app/blueprints/file_manager/routes.py
@@ -35,6 +35,7 @@ def file_manager():
     raw_files = file_manager_instance.list_files('raw')
     spreadsheet_files = [f for f in raw_files if f.endswith(('.xls', '.xlsx'))]
     spreadsheet_form.file_choice.choices = [(f, f) for f in spreadsheet_files]
+    clean_files_with_columns = file_manager_instance.list_files_with_columns('clean')
 
     # Handle file upload
     if 'upload' in request.form:
@@ -69,6 +70,7 @@ def file_manager():
 
     return render_template('file_manager.html',
                            upload_form=upload_form, raw_files=raw_files, clean_files=clean_files,
+                           clean_files_with_columns=clean_files_with_columns,
                            table_html=table_html, spreadsheet_form=spreadsheet_form)
 
 

--- a/app/modules/file_management.py
+++ b/app/modules/file_management.py
@@ -39,6 +39,25 @@ class FileManagement:
             return []
         return [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
 
+    def list_files_with_columns(self, directory):
+        directory_path = self._get_directory(directory)
+        if not os.path.exists(directory_path):
+            return []
+
+        files_with_columns = []
+        for file in os.listdir(directory_path):
+            file_path = os.path.join(directory_path, file)
+            if os.path.isfile(file_path) and file.endswith('.csv'):
+                try:
+                    # Read only the first row to get the columns
+                    df = pd.read_csv(file_path, nrows=1)
+                    column_count = len(df.columns)
+                    files_with_columns.append((file, column_count))
+                except Exception as e:
+                    # Handle exceptions or log errors as needed
+                    files_with_columns.append((file, 'Error'))
+        return files_with_columns
+
     def upload_file(self, file, directory_type='raw'):
         if not file:
             return 'No file provided'

--- a/app/templates/file_manager.html
+++ b/app/templates/file_manager.html
@@ -80,11 +80,12 @@
 
         <div class="col-md-6">
             <h3 class="mb-lg-1 mt-lg-4">CSV files in data/clean</h3>
+            <p>[Number] = number of columns in file</p>
             <form action="{{ url_for('file_manager.file_manager') }}" method="post">
-                {% for file in clean_files %}
+                {% for file, column_count in clean_files_with_columns %}
                     <div class="form-check">
                         <input class="form-check-input" type="radio" name="file_choice" value="{{ file }}">
-                        <label class="form-check-label">{{ file }}</label>
+                        <label class="form-check-label">{{ file }} [{{ column_count }}]</label>
                     </div>
                 {% endfor %}
                 <button type="submit" class="btn btn-outline-primary btn-sm">View File</button>


### PR DESCRIPTION
Modified the file manager to include column count information for each cleaned CSV file. A function has been added to get the count of columns for each file. This count is now being displayed next to each file name in the file manager view of the application.